### PR TITLE
Bug fix: Changed point score variable name

### DIFF
--- a/game/scenes/chapter5.rpy
+++ b/game/scenes/chapter5.rpy
@@ -284,10 +284,10 @@ label chapter5:
     #Add/remove points from total accordingly.
 
     "SHOW SCORE"
-
-    $Kanna = game_player.getRelationship('Kanna')
-    $Maya = game_player.getRelationship('Charlotte')
-    "We Kanna has [Kanna] and Charlotte has [Charlotte]"
+    ####This is an example of how to properly show score. Please look at the variables used. 
+    $Kanna_points = game_player.getRelationship('Kanna')
+    $Charlotte_points = game_player.getRelationship('Charlotte')
+    "We Kanna has [Kanna_points] and Charlotte has [Charlotte_points]"
 
 
     jump chapter6


### PR DESCRIPTION
Changed names of variables used to store character points due to overlap with character object. 

This is an example of how to properly show score. Please look at the variables used. 

    $Kanna_points = game_player.getRelationship('Kanna')
    $Charlotte_points = game_player.getRelationship('Charlotte')
    "We Kanna has [Kanna_points] and Charlotte has [Charlotte_points]"